### PR TITLE
Correspond to Scala 2.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,10 +6,10 @@ version := "0.1.5"
 
 parallelExecution in Test := false
 
-scalaVersion := "2.12.1"
+scalaVersion := "2.12.4"
 
 crossScalaVersions := Seq(
-  "2.12.1",
+  "2.12.4",
   "2.11.0",
   "2.10.3"
 )
@@ -28,7 +28,7 @@ libraryDependencies <++= scalaVersion {
   case sv if (sv startsWith "2.11") || (sv startsWith "2.12") => Seq(
     "org.scala-lang.modules" %% "scala-parser-combinators" % "1.0.5",
     "com.typesafe.akka" %% "akka-actor" % "2.4.17",
-    "org.scalatest" %% "scalatest" % "3.0.1" % "test"
+    "org.scalatest" %% "scalatest" % "3.0.4" % "test"
   )
   case sv if sv startsWith "2.10" => Seq(
     "com.typesafe.akka" %% "akka-actor" % "2.1.0",

--- a/src/main/scala/dsl.scala
+++ b/src/main/scala/dsl.scala
@@ -81,7 +81,7 @@ trait CronParsers extends RegexParsers {
   }
 
   // Month Values
-  def monthValue = (monthnames).mkString("|").r ^^ {
+  def monthValue: Parser[Map[String, String]] = (monthnames).mkString("|").r ^^ {
     case month => Map("month" -> (monthnames.indexOf(month) + 1).toString)
   }
 

--- a/src/test/scala/cron.scala
+++ b/src/test/scala/cron.scala
@@ -4,81 +4,79 @@ package test
 
 import scalendar._
 
-import org.scalatest.FlatSpec
-import org.scalatest.BeforeAndAfterAll
-import org.scalatest.matchers.ShouldMatchers
+import org.scalatest._
 
-class CronTest extends FlatSpec with ShouldMatchers with BeforeAndAfterAll {
+class CronTest extends FlatSpec with Matchers with BeforeAndAfterAll {
 
   override def afterAll() = {
     Scheduled.shutdown()
   }
 
   "Cron dialect" should "be parsable" in {
-    "every day at midnight".crons should be === "0 0 * * *" 
-    "every 15 minutes at noon".crons should be === "*/15 12 * * *"
-    "every 2nd day in April at 3:30".crons should be === "30 3 2 4 *"
-    "every day on Monday at 3:30".crons should be === "30 3 * * 1"
-    "every day on the weekday at 3:30".crons should be === "30 3 * * 1-5"
-    "every 3 days in July on the weekend at 6:57".crons should be === "57 6 */3 7 0,6"
+    "every day at midnight".crons should === ("0 0 * * *" )
+    "every 15 minutes at noon".crons should === ("*/15 12 * * *")
+    "every 2nd day in April at 3:30".crons should === ("30 3 2 4 *")
+    "every day on Monday at 3:30".crons should === ("30 3 * * 1")
+    "every day on the weekday at 3:30".crons should === ("30 3 * * 1-5")
+    "every 3 days in July on the weekend at 6:57".crons should === ("57 6 */3 7 0,6")
   }
 
   "Cron connectors" should "be interchangable" in {
-    "Every other month on the weekday at midnight".crons should be === "0 0 * */2 1-5"
-    "Every other month at midnight on the weekday".crons should be === "0 0 * */2 1-5"
+    "Every other month on the weekday at midnight".crons should === ("0 0 * */2 1-5")
+    "Every other month at midnight on the weekday".crons should === ("0 0 * */2 1-5")
   }
 
   "Cron syntax" should "support the 'last' keyword" in {
-    "Every month on the last Saturday".crons should be === "* * * * 6L"
-    "Every last day".crons should be === "* * L * *"
-    evaluating { "Every last month".cron } should produce [Exception]
+    "Every month on the last Saturday".crons should === ("* * * * 6L")
+    "Every last day".crons should === ("* * L * *")
+    an[Exception] should be thrownBy { "Every last month".cron }
   }
 
   it should "support repitition" in {
-    "every day in April, June, and August at midnight".crons should be === "0 0 * 4,6,8 *"
-    "every month at midnight and noon on Sunday".crons should be === "0 0,12 * * 0"
-    "every 3 hours on Monday, Wednesday, and Friday".crons should be === "* */3 * * 1,3,5"
-    "every month on the 1st, 3rd, 4th, and 8th days".crons should be === "* * 1,3,4,8 * *"
-    "every day at 1am, 4am, 12pm, and 1pm".crons should be === "0 1,4,12,13 * * *"
+    "every day in April, June, and August at midnight".crons should === ("0 0 * 4,6,8 *")
+    "every month at midnight and noon on Sunday".crons should === ("0 0,12 * * 0")
+    "every 3 hours on Monday, Wednesday, and Friday".crons should === ("* */3 * * 1,3,5")
+    "every month on the 1st, 3rd, 4th, and 8th days".crons should === ("* * 1,3,4,8 * *")
+    "every day at 1am, 4am, 12pm, and 1pm".crons should === ("0 1,4,12,13 * * *")
   }
 
   it should "support lists (-)" in {
-    "every day in January through October".crons should be === "* * * 1-10 *"
-    "every day in January to October".crons should be === "* * * 1-10 *"
-    "every day in January-October".crons should be === "* * * 1-10 *"
-    "every month on Wednesday through Saturday".crons should be === "* * * * 3-6"
-    "every month on Wednesday to Saturday".crons should be === "* * * * 3-6"
-    "every month on Wednesday-Saturday".crons should be === "* * * * 3-6"
-    "every other day at midnight to noon".crons should be === "0 0-12 */2 * *"
-    "every 3 minutes at 1am-8pm".crons should be === "*/3 1-20 * * *"
-    "every 3 minutes at 1am-8pm in the year 2013".cron.year should be === "2013"
+    "every day in January through October".crons should === ("* * * 1-10 *")
+    "every day in January to October".crons should === ("* * * 1-10 *")
+    "every day in January-October".crons should === ("* * * 1-10 *")
+    "every month on Wednesday through Saturday".crons should === ("* * * * 3-6")
+    "every month on Wednesday to Saturday".crons should === ("* * * * 3-6")
+    "every month on Wednesday-Saturday".crons should === ("* * * * 3-6")
+    "every other day at midnight to noon".crons should === ("0 0-12 */2 * *")
+    "every 3 minutes at 1am-8pm".crons should === ("*/3 1-20 * * *")
+    "every 3 minutes at 1am-8pm in the year 2013".cron.year should === ("2013")
   }
 
   it should "support incrementals inside connectors" in {
-    "every day in every month at midnight".crons should be === "0 0 * * *"
-    "every last day in every month at every 4 hours".crons should be === "* */4 L * *"
-    "every month on the last day at every 4 hours".crons should be === "* */4 L * *"
-    "every Friday on the last day in every month at midnight".crons should be === "0 0 L * 5"
+    "every day in every month at midnight".crons should === ("0 0 * * *")
+    "every last day in every month at every 4 hours".crons should === ("* */4 L * *")
+    "every month on the last day at every 4 hours".crons should === ("* */4 L * *")
+    "every Friday on the last day in every month at midnight".crons should === ("0 0 L * 5")
   }
 
   it should "support the special day of week syntax" in {
-    "every month on the last Friday at midnight".crons should be === "0 0 * * 5L"
-    "every month on the 2nd Friday at midnight".crons should be === "0 0 * * 5#2"
-    "every last Friday at midnight".crons should be === "0 0 * * 5L"
-    "every other Friday at midnight".crons should be === "0 0 * * 5/2"
+    "every month on the last Friday at midnight".crons should === ("0 0 * * 5L")
+    "every month on the 2nd Friday at midnight".crons should === ("0 0 * * 5#2")
+    "every last Friday at midnight".crons should === ("0 0 * * 5L")
+    "every other Friday at midnight".crons should === ("0 0 * * 5/2")
   }
 
   it should "support the special time keywords" in {
-    "every midnight".crons should be === "every day at midnight".crons
-    "every midnight on the last Friday".crons should be === "0 0 * * 5L"
+    "every midnight".crons should === ("every day at midnight".crons)
+    "every midnight on the last Friday".crons should === ("0 0 * * 5L")
   }
 
   "Predefined crons" should "be correct" in {
-    hourly.toString should be === "0 * * * *"
-    daily.toString should be === "0 0 * * *"
-    weekly.toString should be === "0 0 * * 0"
-    monthly.toString should be === "0 0 1 * *"
-    yearly.toString should be === "0 0 1 1 *"
+    hourly.toString should === ("0 * * * *")
+    daily.toString should === ("0 0 * * *")
+    weekly.toString should === ("0 0 * * 0")
+    monthly.toString should === ("0 0 1 * *")
+    yearly.toString should === ("0 0 1 1 *")
   }
 
   "A cron task" should "be able to be built fluently" in {
@@ -86,11 +84,11 @@ class CronTest extends FlatSpec with ShouldMatchers with BeforeAndAfterAll {
       println("Building something leet")
     }
 
-    test.isInstanceOf[CronTask] should be === true
+    test.isInstanceOf[CronTask] should === (true)
 
     val testjob = test executes "every second"
 
-    testjob.isInstanceOf[Scheduled] should be === true
+    testjob.isInstanceOf[Scheduled] should === (true)
     testjob.stop()
   }
 
@@ -107,14 +105,14 @@ class CronTest extends FlatSpec with ShouldMatchers with BeforeAndAfterAll {
     // We'll sleep for a second
     Thread.sleep(1 * 1000)
 
-    runs should be === 1
+    runs should === (1)
     exampleJob.stop()
   }
 
   it should "be able to be stopped at any time" in {
     var counter = 0
     task { counter += 1 } executes "every second" stop()
-    counter should be === 0
+    counter should === (0)
   }
 
   it should "be able to have a user defined description" in {
@@ -125,8 +123,8 @@ class CronTest extends FlatSpec with ShouldMatchers with BeforeAndAfterAll {
       println("Blah blah")
     } describedAs expected executes daily
 
-    nodesc.task.description should be === None
-    other.task.description should be === Some(expected)
+    nodesc.task.description should === (None)
+    other.task.description should === (Some(expected))
 
     nodesc.stop()
     other.stop()
@@ -137,16 +135,16 @@ class CronTest extends FlatSpec with ShouldMatchers with BeforeAndAfterAll {
     val countTask = job { counter += 1 } describedAs "Delayed Starts"
     val delayed = countTask runs "every second" in 100.milliseconds
 
-    counter should be === 0
+    counter should === (0)
     Thread.sleep(1100)
     delayed.stop()
-    counter should be === 1
+    counter should === (1)
 
     import Scalendar.now
     val other = countTask executes "every second" starting now
     Thread.sleep(1000)
     other.stop()
-    counter should be === 2
+    counter should === (2)
   }
 
   it should "be able to be reset and delayed fluently" in {
@@ -168,7 +166,7 @@ class CronTest extends FlatSpec with ShouldMatchers with BeforeAndAfterAll {
     val active = Scheduled.active
 
     val expected = "Tell him later on dude"
-    active.map(_.task.description.get).mkString(" ") should be === expected
+    active.map(_.task.description.get).mkString(" ") should === (expected)
 
     active.foreach(_.stop())
   }
@@ -176,7 +174,7 @@ class CronTest extends FlatSpec with ShouldMatchers with BeforeAndAfterAll {
   "A Scheduled job" should "be able to handle errors optionally" in {
     val exampleJob = job (throw new RuntimeException("Catch this"))
 
-    exampleJob catches (_.getMessage should be === "Catch this")
+    exampleJob catches (_.getMessage should === ("Catch this"))
 
     val running = exampleJob runs "every second"
 
@@ -192,7 +190,7 @@ class CronTest extends FlatSpec with ShouldMatchers with BeforeAndAfterAll {
 
     exampleJob runs "every second" stop()
 
-    counter should be === 0
+    counter should === (0)
   }
 
   it should "be able to run an exact number of times or forever" in {
@@ -251,7 +249,7 @@ class CronTest extends FlatSpec with ShouldMatchers with BeforeAndAfterAll {
 
       val result = Scalendar(n.time + millis)
 
-      result should be === expected(n)
+      result should === (expected(n))
     }
   }
 
@@ -264,7 +262,7 @@ class CronTest extends FlatSpec with ShouldMatchers with BeforeAndAfterAll {
                      Cron("*", "*", "*", "*", "*", s"1,${now.day.inWeek -1},6", "*"))
 
     crons.foreach(cron => {
-      Scalendar.beginDay(cron.nextTime) should be === Scalendar.beginDay(now)
+      Scalendar.beginDay(cron.nextTime) should === (Scalendar.beginDay(now))
     })
   }
 }


### PR DESCRIPTION
Correspond to Scala 2.12.4.

I'm resolved compile errors

```
$ sbt compile

[error] /Users/kiris/local/src/cronish/src/main/scala/dsl.scala:84: recursive method monthnames needs result type
[error]   def monthValue = (monthnames).mkString("|").r ^^ {
[error] /Users/kiris/local/src/cronish/src/main/scala/dsl.scala:217: value getOrElse is not a member of Any
[error]           parsed.getOrElse("second", "0"),
```

and test compile errors.

```
$ sbt test

[error] /Users/kiris/local/src/cronish/src/test/scala/cron.scala:9: object ShouldMatchers is not a member of package org.scalatest.matchers
[error] import org.scalatest.matchers.ShouldMatchers
[error]        ^
[error] /Users/kiris/local/src/cronish/src/test/scala/cron.scala:11: not found: type ShouldMatchers
[error] class CronTest extends FlatSpec with ShouldMatchers with BeforeAndAfterAll {
```

